### PR TITLE
return the operation

### DIFF
--- a/lib/afmotion/http_client.rb
+++ b/lib/afmotion/http_client.rb
@@ -136,6 +136,7 @@ class AFHTTPClient
             callback.call(result)
           })
         self.enqueueHTTPRequestOperation(@operation)
+        @operation
       end
     end
   end


### PR DESCRIPTION
return operation from afhttpclient so you can cancel it if needed
