### PR TITLE
Check if NSURLSessionTask is defined

### DIFF
--- a/lib/afmotion/http_result.rb
+++ b/lib/afmotion/http_result.rb
@@ -3,7 +3,7 @@ module AFMotion
     attr_accessor :operation, :object, :error, :task
 
     def initialize(operation_or_task, responseObject, error)
-      if operation_or_task.is_a?(NSURLSessionTask) ||
+      if defined?(NSURLSessionTask) && operation_or_task.is_a?(NSURLSessionTask) ||
         # cluser class ugh
         operation_or_task.class.to_s.include?("Task")
         self.task = operation_or_task


### PR DESCRIPTION
When I use

```
    AFMotion::Client.build_shared(base_url) do
      header "Accept", "application/json"

      response_serializer :json
    end
```

and run

 `rake target=6.0

I'll get an error saying NSUrlSessionTask isn't there. I believe the check should be as stated in the pull request.

`http_result.rb:6:in initialize:': uninitialized constant AFMotion::HTTPResult::NSURLSessionTask (NameError)
    from operation.rb:26:in`block in failure_block:'
