### PR TITLE
Add pod install to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ You can also request arbitrary images:
 
 2. `require 'afmotion'` or add to your `Gemfile`
 
+3. `rake pod:install`
+
 ## Overview
 
 ### Results


### PR DESCRIPTION
I'm not 100% sure this is necessary but it wouldn't work for me without (though I only installed via `bundle install` not `gem install`).

Also; not sure what the last line in the diff is about…
