### PR TITLE
Remove explicit motion-require dependency.

### DIFF
--- a/AFMotion.gemspec
+++ b/AFMotion.gemspec
@@ -16,6 +16,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "motion-cocoapods", "~> 1.4.0"
-  s.add_dependency "motion-require", "~> 0.1.0"
   s.add_development_dependency 'rake'
 end


### PR DESCRIPTION
motion-require just got updated to `2.0.0` and this gem still works fine :)
