### PR TITLE
Remove old gem version reference in the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ You can also request arbitrary images:
 
 1. `gem install afmotion`
 
-2. `require 'afmotion'` or add to your `Gemfile` (`gem 'afmotion', '~> 2.1.0'`)
+2. `require 'afmotion'` or add to your `Gemfile` (`gem 'afmotion'`)
 
 3. `rake pod:install`
 


### PR DESCRIPTION
People could be copy/pasting from the readme into their gemfile, locking them into a 2 month old (at the time of this PR) version.
