### PR TITLE
update deprecated method signature

### DIFF
--- a/lib/afmotion/session_client.rb
+++ b/lib/afmotion/session_client.rb
@@ -91,7 +91,7 @@ module AFMotion
     SESSION_CONFIGURATION_SHORTHAND = {
       default: :defaultSessionConfiguration,
       ephemeral: :ephemeralSessionConfiguration,
-      background: "backgroundSessionConfiguration:".to_sym
+      background: "backgroundSessionConfigurationWithIdentifier:".to_sym
     }
 
     def session_configuration(session_configuration, identifier = nil)


### PR DESCRIPTION
Fix warnings by updating to the non deprecated method name
