### PR TITLE
Add nil check for #status_code

### DIFF
--- a/lib/afmotion/http_result.rb
+++ b/lib/afmotion/http_result.rb
@@ -27,6 +27,8 @@ module AFMotion
         self.operation.response.statusCode
       elsif self.task
         self.task.response.statusCode
+      else
+        nil
       end
     end
 


### PR DESCRIPTION
Added a nil check in `#status_code` for when `self.operation` is not set, should resolves #66.

Thoughts?
