### PR TITLE
Client DSL should be order agnostic

### DIFF
--- a/spec/http_client_spec.rb
+++ b/spec/http_client_spec.rb
@@ -30,6 +30,18 @@ describe "AFMotion::ClientDSL" do
         @client.requestSerializer.is_a?(op_class).should == true
       end
     end
+
+    it "should retain header configuration" do
+      @dsl.header "X-Order", "agnostic"
+      @dsl.request_serializer :json
+      @client.requestSerializer.HTTPRequestHeaders["X-Order"].should == "agnostic"
+    end
+
+    it "should retain authorization" do
+      @dsl.authorization username: "clay", password: "test"
+      @dsl.request_serializer :json
+      @client.requestSerializer.HTTPRequestHeaders["Authorization"].nil?.should == false
+    end
   end
 
   describe "#response_serializer" do


### PR DESCRIPTION
The DSL shouldn't care whether headers are set before the request serializer. See #78 

This PR currently just includes a failing spec for the issue. If this is something that should be fixed, then I can take a stab at an implementation :)