### PR TITLE
Progress block for shared clients

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,3 +69,6 @@ DEPENDENCIES
   afmotion!
   rake
   webstub (~> 1.1)
+
+BUNDLED WITH
+   1.10.4

--- a/lib/afmotion/client_shared.rb
+++ b/lib/afmotion/client_shared.rb
@@ -110,7 +110,9 @@ module AFMotion
       success_block = AFMotion::Operation.success_block_for_http_method(http_method, callback)
       failure_block = AFMotion::Operation.failure_block(callback)
       operation = method.call(path, parameters, success_block, failure_block)
-      operation.setDownloadProgressBlock(parameters.delete(:progress_block)) if parameters && parameters[:progress_block]
+      if parameters && parameters[:progress_block] && operation.respond_to?(:setDownloadProgressBlock)
+        operation.setDownloadProgressBlock(parameters.delete(:progress_block))
+      end
       operation
     end
 

--- a/lib/afmotion/client_shared.rb
+++ b/lib/afmotion/client_shared.rb
@@ -109,7 +109,7 @@ module AFMotion
       method = self.method(method_signature)
       success_block = AFMotion::Operation.success_block_for_http_method(http_method, callback)
       operation = method.call(path, parameters, success_block, AFMotion::Operation.failure_block(callback))
-      operation.setDownloadProgressBlock(parameters.delete(:download_progress_block)) if parameters[:download_progress_block]
+      operation.setDownloadProgressBlock(parameters.delete(:progress_block)) if parameters[:progress_block]
       operation
     end
 

--- a/lib/afmotion/client_shared.rb
+++ b/lib/afmotion/client_shared.rb
@@ -109,6 +109,8 @@ module AFMotion
       method = self.method(method_signature)
       success_block = AFMotion::Operation.success_block_for_http_method(http_method, callback)
       operation = method.call(path, parameters, success_block, AFMotion::Operation.failure_block(callback))
+      operation.setDownloadProgressBlock(parameters.delete(:download_progress_block)) if parameters[:download_progress_block]
+      operation
     end
 
     alias_method :create_task, :create_operation

--- a/lib/afmotion/client_shared.rb
+++ b/lib/afmotion/client_shared.rb
@@ -108,8 +108,8 @@ module AFMotion
       method_signature = "#{http_method.upcase}:parameters:success:failure:"
       method = self.method(method_signature)
       success_block = AFMotion::Operation.success_block_for_http_method(http_method, callback)
-      operation = method.call(path, parameters, success_block, AFMotion::Operation.failure_block(callback))
-      operation.setDownloadProgressBlock(parameters.delete(:progress_block)) if parameters[:progress_block]
+      failure_block = AFMotion::Operation.failure_block(callback)
+      operation = method.call(path, parameters, success_block, failure_block)
       operation
     end
 

--- a/lib/afmotion/client_shared.rb
+++ b/lib/afmotion/client_shared.rb
@@ -110,6 +110,7 @@ module AFMotion
       success_block = AFMotion::Operation.success_block_for_http_method(http_method, callback)
       failure_block = AFMotion::Operation.failure_block(callback)
       operation = method.call(path, parameters, success_block, failure_block)
+      operation.setDownloadProgressBlock(parameters.delete(:progress_block)) if parameters && parameters[:progress_block]
       operation
     end
 

--- a/lib/afmotion/http.rb
+++ b/lib/afmotion/http.rb
@@ -44,7 +44,9 @@ module AFMotion
     AFMotion::HTTP_METHODS.each do |method_name|
       method_signature = "#{method_name.to_s.upcase}:parameters:success:failure:"
       base.define_singleton_method(method_name, -> (url, parameters = nil, &callback) do
-        base.operation_manager.send(method_signature, url,
+        manager = base.operation_manager
+        manager.setDownloadProgressBlock(parameters.delete(:progress_block)) if parameters[:progress_block]
+        manager.send(method_signature, url,
           parameters,
           AFMotion::Operation.success_block_for_http_method(method_name, callback),
           AFMotion::Operation.failure_block(callback))

--- a/lib/afmotion/http.rb
+++ b/lib/afmotion/http.rb
@@ -45,7 +45,6 @@ module AFMotion
       method_signature = "#{method_name.to_s.upcase}:parameters:success:failure:"
       base.define_singleton_method(method_name, -> (url, parameters = nil, &callback) do
         manager = base.operation_manager
-        manager.setDownloadProgressBlock(parameters.delete(:progress_block)) if parameters && parameters[:progress_block]
         manager.send(method_signature, url,
           parameters,
           AFMotion::Operation.success_block_for_http_method(method_name, callback),

--- a/lib/afmotion/http.rb
+++ b/lib/afmotion/http.rb
@@ -45,7 +45,7 @@ module AFMotion
       method_signature = "#{method_name.to_s.upcase}:parameters:success:failure:"
       base.define_singleton_method(method_name, -> (url, parameters = nil, &callback) do
         manager = base.operation_manager
-        manager.setDownloadProgressBlock(parameters.delete(:progress_block)) if parameters[:progress_block]
+        manager.setDownloadProgressBlock(parameters.delete(:progress_block)) if parameters && parameters[:progress_block]
         manager.send(method_signature, url,
           parameters,
           AFMotion::Operation.success_block_for_http_method(method_name, callback),

--- a/spec/http_client_spec.rb
+++ b/spec/http_client_spec.rb
@@ -87,6 +87,23 @@ describe "AFMotion::Client" do
       client = AFMotion::Client.build_shared("http://url")
       AFMotion::Client.shared.should == client
     end
+
+    it "should call progress when given to a chared client" do
+      image_path = "images/srpr/logo3w.png"
+      client = AFMotion::Client.build_shared("https://www.google.com/")
+      @progression = []
+      progress_block = Proc.new do |bytesRead, totalBytesRead, totalBytesExpectedToRead|
+        @progression << [bytesRead, totalBytesRead, totalBytesExpectedToRead]
+      end
+
+      client.get(image_path, {progress_block: progress_block}) do |result|
+        @result = result
+        resume
+      end
+      wait_max(10) do
+        @progression.empty?.should == false
+      end
+    end
   end
 end
 

--- a/spec/session_client_spec.rb
+++ b/spec/session_client_spec.rb
@@ -177,6 +177,24 @@ describe "AFHTTPSessionManager" do
     end
   end
 
+  describe "progress" do
+    it "should call the progress block" do
+      @progression = []
+      progress_block = Proc.new do |bytesRead, totalBytesRead, totalBytesExpectedToRead|
+        @progression << [bytesRead, totalBytesRead, totalBytesExpectedToRead]
+      end
+
+      @client.get("http://google.com", {progress_block: progress_block}) do |result|
+        @result = result
+        resume
+      end
+      wait_max(10) do
+        @progression.empty?.should == false
+      end
+    end
+
+  end
+
 
   ["multipart_post", "multipart_put"].each do |multipart_method|
     describe "##{multipart_method}" do

--- a/spec/session_client_spec.rb
+++ b/spec/session_client_spec.rb
@@ -177,25 +177,6 @@ describe "AFHTTPSessionManager" do
     end
   end
 
-  describe "progress" do
-    it "should call the progress block" do
-      @progression = []
-      progress_block = Proc.new do |bytesRead, totalBytesRead, totalBytesExpectedToRead|
-        @progression << [bytesRead, totalBytesRead, totalBytesExpectedToRead]
-      end
-
-      @client.get("http://google.com", {progress_block: progress_block}) do |result|
-        @result = result
-        resume
-      end
-      wait_max(10) do
-        @progression.empty?.should == false
-      end
-    end
-
-  end
-
-
   ["multipart_post", "multipart_put"].each do |multipart_method|
     describe "##{multipart_method}" do
       it "should trigger multipart request" do

--- a/vendor/Podfile.lock
+++ b/vendor/Podfile.lock
@@ -25,6 +25,6 @@ DEPENDENCIES:
   - AFNetworking (~> 2.5)
 
 SPEC CHECKSUMS:
-  AFNetworking: 0f54cb5d16ce38c1b76948faffb8d5fb705021c7
+  AFNetworking: 96ac9bf3eda33582701cb1fcc5b896aa1e20311e
 
 COCOAPODS: 0.36.0


### PR DESCRIPTION
Previously there was no way to get download progress (through AFNetworking's `setDownloadProgressBlock`) with a shared client.

Example usage in the included test.