### PR TITLE
Fixes iOS 8 deprecation warning:

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,4 +13,5 @@ require 'webstub'
 Motion::Project::App.setup do |app|
   # Use `rake config' to see complete project settings.
   app.name = 'AFMotion'
+  app.deployment_target = "7.1"
 end

--- a/lib/afmotion/session_client.rb
+++ b/lib/afmotion/session_client.rb
@@ -91,7 +91,7 @@ module AFMotion
     SESSION_CONFIGURATION_SHORTHAND = {
       default: :defaultSessionConfiguration,
       ephemeral: :ephemeralSessionConfiguration,
-      background: "backgroundSessionConfiguration:".to_sym
+      background: (UIDevice.currentDevice.systemVersion.to_f >= 8.0 ? "backgroundSessionConfigurationWithIdentifier:" : "backgroundSessionConfiguration:").to_sym
     }
 
     def session_configuration(session_configuration, identifier = nil)


### PR DESCRIPTION
```
+backgroundSessionConfiguration: is deprecated. Please use +backgroundSessionConfigurationWithIdentifier: instead
```

Also added the deploy target to iOS 7.1 so that tests can run in iOS 7 but it's a PITA to get them running on a different device on travis.