### PR TITLE
Make head operations call the callback appropriately.

### DIFF
--- a/lib/afmotion/operation.rb
+++ b/lib/afmotion/operation.rb
@@ -11,7 +11,8 @@ module AFMotion
     def success_block_for_http_method(http_method, callback)
       if http_method.downcase.to_sym == :head
         return lambda { |operation_or_task|
-          AFMotion::HTTPResult.new(operation_or_task, nil, nil)
+          result = AFMotion::HTTPResult.new(operation_or_task, nil, nil)
+          callback.call(result)
         }
       end
 

--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -25,6 +25,23 @@ describe "AFMotion" do
           end
         end
       end
+
+      describe ".head" do
+        before do
+          @result = nil
+        end
+
+        it "should work with string" do
+          _module.head("http://google.com") do |result|
+            @result = result
+            resume
+          end
+          wait_max(10) do
+            @result.nil?.should == false
+          end
+        end
+      end
+
     end
   end
 


### PR DESCRIPTION
It was unclear to me why the HEAD operation should NOT call the callback; it seems like HEAD failure does call the callback, so at the very least it's inconsistent.