### PR TITLE
Fixes crash in OS X because of undefined constant `UIDevice`

### DIFF
--- a/lib/afmotion/session_client.rb
+++ b/lib/afmotion/session_client.rb
@@ -91,7 +91,7 @@ module AFMotion
     SESSION_CONFIGURATION_SHORTHAND = {
       default: :defaultSessionConfiguration,
       ephemeral: :ephemeralSessionConfiguration,
-      background: (UIDevice.currentDevice.systemVersion.to_f >= 8.0 ? "backgroundSessionConfigurationWithIdentifier:" : "backgroundSessionConfiguration:").to_sym
+      background: (Object.const_defined?("UIDevice") && UIDevice.currentDevice.systemVersion.to_f >= 8.0 ? "backgroundSessionConfigurationWithIdentifier:" : "backgroundSessionConfiguration:").to_sym
     }
 
     def session_configuration(session_configuration, identifier = nil)

--- a/spec/session_client_spec.rb
+++ b/spec/session_client_spec.rb
@@ -223,7 +223,7 @@ describe "AFHTTPSessionManager" do
 
         wait_max(20) do
           @file_added.should == true
-          if (UIDevice.currentDevice.model =~ /simulator/i).nil?
+          if (Object.const_defined?("UIDevice") && UIDevice.currentDevice.model =~ /simulator/i).nil?
             @progress.should <= 1.0
             @progress.should.not == nil
           end


### PR DESCRIPTION
Closes #105