### PR TITLE
small fix to http_result

### DIFF
--- a/lib/afmotion/http_result.rb
+++ b/lib/afmotion/http_result.rb
@@ -25,7 +25,7 @@ module AFMotion
     def status_code
       if self.operation && self.operation.response
         self.operation.response.statusCode
-      elsif self.task
+      elsif self.task && self.task.response
         self.task.response.statusCode
       else
         nil


### PR DESCRIPTION
small fix to http_result that prevented from getting nil status_code under no connection or server down status